### PR TITLE
Disable Tag Creation in Sign-up and Edit Profile

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -70,7 +70,7 @@ const userSchema = new mongoose.Schema({
   department: {
     type: String,
   },
-  timeline : [{
+  testTimeline : [{
     name :  String,
     date : Date,
     score : Number

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -18,12 +18,13 @@ const theme = createMuiTheme({
 
 function App() {
 
-  const [loggedIn, setLoggedIn] = React.useState(0);
+  const [loggedIn, setLoggedIn] = React.useState(1);
 
   //Function to be called while Refreshing a token
   const handleTokenRefresh = () => {
     const refToken = Cookies.get('refToken')
     if(!refToken || !!Cookies.get('jwt')){
+      setLoggedIn(0);
       return
     }
     else{
@@ -35,7 +36,7 @@ function App() {
         setLoggedIn(1);
       })
       .catch(function(error){
-        console.log(error);
+        setLoggedIn(0);
       });
     }
   };
@@ -52,12 +53,10 @@ function App() {
             setLoggedIn(1);
           })
           .catch(function (error) {
-            console.log(error);
             setLoggedIn(0);
           }); 
         }
         else{
-            setLoggedIn(0);
             handleTokenRefresh();
         }
     },[loggedIn])

--- a/webapp/src/Components/editProfile.js
+++ b/webapp/src/Components/editProfile.js
@@ -228,9 +228,9 @@ function EditProfile(props) {
 			            if (values.gradDate.trim()===''){
 			            	errors.gradDate = "Cannot be empty"
 			            }
-			            if (values.university.trim()===''){
-			            	errors.university = "Cannot be empty"
-			            }
+			            // if (values.university.trim()===''){
+			            // 	errors.university = "Cannot be empty"
+			            // }
 			            return errors;
 			          }}
 			          onSubmit={async (values, { setSubmitting }) => {

--- a/webapp/src/Components/editProfile.js
+++ b/webapp/src/Components/editProfile.js
@@ -5,7 +5,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
-import Autocomplete from '@material-ui/lab/Autocomplete';
+import Autocomplete,{createFilterOptions} from '@material-ui/lab/Autocomplete';
 import MenuItem from '@material-ui/core/MenuItem';
 import Chip from '@material-ui/core/Chip';
 import Snackbar from '@material-ui/core/Snackbar';
@@ -56,7 +56,7 @@ const useStyles = makeStyles(theme => ({
 		color: '#fff',
 	},
 }));
-
+const filter = createFilterOptions();
 function EditProfile(props) {
 
 	const [user] = React.useState({
@@ -222,6 +222,15 @@ function EditProfile(props) {
 			            ) {
 			              errors.email = 'Invalid email address';
 			            }
+			            if (values.department.trim()===''){
+			            	errors.department = "Cannot be empty"
+			            }
+			            if (values.gradDate.trim()===''){
+			            	errors.gradDate = "Cannot be empty"
+			            }
+			            if (values.university.trim()===''){
+			            	errors.university = "Cannot be empty"
+			            }
 			            return errors;
 			          }}
 			          onSubmit={async (values, { setSubmitting }) => {
@@ -271,7 +280,7 @@ function EditProfile(props) {
 					      department: user.department,
 					      bio: user.bio,
 					      domains: domains,
-					      timeline: user.tests,
+					      testTimeline: user.tests,
 					      linkedinUrl: user.linkedIn,
 					      githubUrl: user.github,
 					      facebookUrl: user.facebook,
@@ -354,7 +363,6 @@ function EditProfile(props) {
 	            </Grid>
 	            <Grid item md={6}>
 	          <Autocomplete
-              freeSolo
               options={universityNames} 
               disableClearable
               inputValue={!!values.university?values.university:''}
@@ -362,10 +370,17 @@ function EditProfile(props) {
               onChange={(e, value) => {
                 setFieldValue("university", value)
               }}
-                onBlur={handleBlur}
-            className={classes.textf}
+              filterOptions={(options, params) => {
+				  const filtered = filter(options, params);
+					if (params.inputValue !== ''&& !filtered.includes("Other")) {
+					filtered.push("Other");
+				   }
+				    return filtered;
+			  }}
+              onBlur={handleBlur}
+              className={classes.textf}
               renderInput={params => (
-                <TextField {...params} name='university' value={values.university} onChange={handleChange} error={!!errors.university&&touched.university} helperText={touched.university?errors.university:''}  label="University" margin="normal" variant="filled" fullWidth />
+                <TextField {...params} name='university' value={values.university} onChange={handleChange} onBlur={()=>(values.university=universityNames.includes(values.university)||values.university===''?values.university:"Other")} error={!!errors.university&&touched.university} helperText={touched.university?errors.university:''}  label="University" margin="normal" variant="filled" fullWidth />
               )}
             />
           <Autocomplete
@@ -377,7 +392,7 @@ function EditProfile(props) {
               onChange={(e, value) => {
                 setFieldValue("department", value)
               }}
-                onBlur={handleBlur}
+              onBlur={handleBlur}
               className={classes.textf}
               renderInput={params => (
                 <TextField {...params} name='department' value={values.department} onChange={handleChange} error={!!errors.department&&touched.department} helperText={touched.department?errors.department:''}  label="Department" margin="normal" variant="filled" fullWidth />
@@ -393,6 +408,8 @@ function EditProfile(props) {
 	            onChange={handleChange}
 	            onBlur={handleBlur}
 	            className={classes.textf}
+	            error={!!errors.gradDate&&touched.gradDate}
+	            helperText={touched.gradDate?errors.gradDate:''}
 	          /> 
 	          <br/><br/>
 	        </Grid>
@@ -424,18 +441,24 @@ function EditProfile(props) {
             </Grid>
             <Grid item xs={6}>
               <Autocomplete
-              freeSolo
               options={tagNames}
               disableClearable
               inputValue={!!values.addDomain?values.addDomain:''}
+              filterOptions={(options, params) => {
+				  const filtered = filter(options, params);
+					if (params.inputValue !== ''&& !filtered.includes("Other")) {
+					filtered.push("Other");
+				   }
+				    return filtered;
+			  }}
               autoHighlight
               getOptionDisabled={option => values.domain.includes(option)}
               name="addDomain"
               onChange={(e, value) => {
                 setFieldValue("addDomain", value)
               }}
-                onBlur={handleBlur}
-            className={classes.textf}
+              onBlur={handleBlur}
+              className={classes.textf}
               renderInput={params => (
                 <TextField 
                   {...params} 
@@ -447,11 +470,10 @@ function EditProfile(props) {
                   variant="filled"
                   helperText="Press enter after adding each domain" 
                   onChange={handleChange}
-                  onBlur={handleBlur}
                   onKeyPress={(event) => {
                     if (event.key === 'Enter') {
                         event.preventDefault();
-                        if (values.addDomain.trim()){
+                        if (values.addDomain.trim()&&tagNames.includes(values.addDomain)&&!values.domain.includes(values.addDomain)){
                           setFieldValue('domain',[...values.domain,values.addDomain]);
                           setFieldValue('addDomain','');
                         }
@@ -668,28 +690,35 @@ function EditProfile(props) {
                     <React.Fragment key={index}>
                       <div>
                       <Autocomplete
-                            freeSolo
-                            options={universityNames} 
-                            key={index}
-                            disableClearable
-                            inputValue={!!value.name?value.name:''}
-                            name={`uniApplied.${index}.name`}
-                            onChange={(e, value) => {
-                              setFieldValue(`uniApplied.${index}.name`, value)
-                            }}
-                            onBlur={handleBlur}
-                            renderInput={params => (
-                              <TextField {...params} 
-                                name={`uniApplied.${index}.name`} 
-                                value={value.name} 
-                                onChange={handleChange} 
-                                label="University Name" 
-                                margin="normal" 
-                                variant="filled" 
-                                fullWidth 
-                              />
-                            )}
+                        options={universityNames} 
+                        key={index}
+                        disableClearable
+                        inputValue={!!value.name?value.name:''}
+                        name={`uniApplied.${index}.name`}
+                        onChange={(e, value) => {
+                          setFieldValue(`uniApplied.${index}.name`, value)
+                        }}
+                        filterOptions={(options, params) => {
+							const filtered = filter(options, params);
+							if (params.inputValue !== ''&& !filtered.includes("Other")){
+								filtered.push("Other");
+							}
+						    return filtered;
+						}}
+                        onBlur={handleBlur}
+                        renderInput={params => (
+                          <TextField {...params} 
+                            name={`uniApplied.${index}.name`} 
+                            value={value.name} 
+                            onChange={handleChange} 
+                            onBlur={()=>(value.name=universityNames.includes(value.name)||value.name===''?value.name:"Other")}
+                            label="University Name" 
+                            margin="normal" 
+                            variant="filled" 
+                            fullWidth 
                           />
+                        )}
+                      />
                     </div><br/>
                  	<div>
                       <TextField 

--- a/webapp/src/Components/editProfile.js
+++ b/webapp/src/Components/editProfile.js
@@ -92,7 +92,6 @@ function EditProfile(props) {
 		if(!mounted){
 		   axios.get('/api/tags')
 		      	.then(function(res){
-		        console.log(res)
 		        res.data.forEach((item)=>{
 		          if(item.isSchool){
 		            if(!universityArr.includes(item)){
@@ -122,7 +121,6 @@ function EditProfile(props) {
 				    }
 				  })
 				  .then(function (response) {
-				  	console.log(response);
 				  	user.id=response.data._id
 				    user.email=response.data.email;
 				    user.name=response.data.name;
@@ -160,7 +158,7 @@ function EditProfile(props) {
 					setMounted(true);
 				  })
 				  .catch(function (error) {
-				    console.log(error);
+				    console.log("Failed to fetch user details");
 				  });  
 				}
 		    });
@@ -270,7 +268,7 @@ function EditProfile(props) {
 		          			  	'content-type': 'multipart/form-data'
 		          			}})
 		          			.then(function(response){
-		          				console.log(response)
+		          				console.log("Picture Uploaded!")
 		          			})
 				        }
             			axios.put('/api/users/me', {
@@ -292,11 +290,10 @@ function EditProfile(props) {
               			  	Authorization: token1
               			  }})
 					    .then(function (response) {
-					      console.log(response);
 			           	  handleOpenMsg();
 					    })
 					    .catch(function (error) {
-					      console.log(error);
+					      console.log("Failed! An error occured. Please try again later");
 					    });
 			            //@Backend Submit Function for Sign-Up
 		        }}

--- a/webapp/src/Components/login.js
+++ b/webapp/src/Components/login.js
@@ -67,23 +67,19 @@ export default function LoginPage(props){
 			        return errors;
 			      }}
 			      onSubmit={(values, { setSubmitting }) => {
-			        console.log(values);
 			        axios.post('/api/users/login', {
 				      email: values.email,
 				      password: values.password
 					  })
 					  .then(function (response) {
-					    console.log(response);
 					    Cookies.set('jwt',response.data.token,{expires: 1});
 					    Cookies.set('refreshToken',response.data.refreshToken,{expires: 7})
-					    console.log(response.data.token);
 					    props.setLoggedIn(1);
 					  })
 					  .catch(function (error) {
 				        setTimeout(() => {
 				          setSubmitting(false);
 				        }, 1000);
-					    console.error(error.code);
 					    setShowWarning(true);
 
 					  });  

--- a/webapp/src/Components/navbar.js
+++ b/webapp/src/Components/navbar.js
@@ -86,12 +86,11 @@ function NavBar(props) {
                 }
               })
               .then(function (response) {
-                console.log(response);
                 setUrl(`/api/users/${response.data._id}/avatar`);
                 setName(response.data.name);
               })
               .catch(function (error) {
-                console.log(error);
+                console.log("Invalid User");
               }); 
         } 
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/webapp/src/Components/register.js
+++ b/webapp/src/Components/register.js
@@ -6,7 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import CloseIcon from '@material-ui/icons/Close';
 import TextField from '@material-ui/core/TextField';
-import Autocomplete from '@material-ui/lab/Autocomplete';
+import Autocomplete,{createFilterOptions} from '@material-ui/lab/Autocomplete';
 import MenuItem from '@material-ui/core/MenuItem';
 import Chip from '@material-ui/core/Chip';
 import Snackbar from '@material-ui/core/Snackbar';
@@ -39,7 +39,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const axios = require('axios');
-
+const filter = createFilterOptions();
 function getSteps() {
     return ['Core Details', 'Other Details'];
 }
@@ -96,7 +96,7 @@ export default function Register(props) {
       /* -------------- Optional Fields below: ------------------ */
       bio: user.bio,
       domains: user.domain,
-      timeline: user.tests,
+      testTimeline: user.tests,
       linkedinUrl: user.linkedIn,
       githubUrl: user.github,
       facebookUrl: user.facebook,
@@ -355,7 +355,6 @@ export default function Register(props) {
             </Grid>
             <Grid item md={6}>
          <Autocomplete
-              freeSolo
               options={universityNames} 
               disableClearable
               inputValue={!!values.university?values.university:''}
@@ -363,10 +362,29 @@ export default function Register(props) {
               onChange={(e, value) => {
                 setFieldValue("university", value)
               }}
-                onBlur={handleBlur}
-            className={classes.textf}
+              filterOptions={(options, params) => {
+                const filtered = filter(options, params);
+                if (params.inputValue !== '' && !filtered.includes("Other")) {
+                  filtered.push("Other");
+                 }
+                  return filtered;
+              }}
+              onBlur={handleBlur}
+              className={classes.textf}
               renderInput={params => (
-                <TextField {...params} name='university' value={values.university} onChange={handleChange} error={!!errors.university&&touched.university} helperText={touched.university?errors.university:''}  label="University" margin="normal" variant="filled" fullWidth />
+                <TextField 
+                  {...params} 
+                  name='university' 
+                  value={values.university} 
+                  onChange={handleChange} 
+                  onBlur={()=>(values.university=universityNames.includes(values.university)||values.university===''?values.university:"Other")} 
+                  error={!!errors.university&&touched.university} 
+                  helperText={!!touched.university?errors.university:''} 
+                  label="University" 
+                  margin="normal" 
+                  variant="filled" 
+                  fullWidth 
+                />
               )}
             />
           <Autocomplete
@@ -493,17 +511,23 @@ export default function Register(props) {
             </Grid>
             <Grid item xs={6}>
              <Autocomplete
-              freeSolo
               options={tagNames}
               disableClearable
               inputValue={!!values.addDomain?values.addDomain:''}
               autoHighlight
               getOptionDisabled={option => values.domain.includes(option)}
+              filterOptions={(options, params) => {
+                const filtered = filter(options, params);
+                if (params.inputValue !== '' && !filtered.includes("Other")) {
+                  filtered.push("Other");
+                }
+                return filtered;
+              }}
               name="addDomain"
               onChange={(e, value) => {
                 setFieldValue("addDomain", value)
               }}
-                onBlur={handleBlur}
+              onBlur={handleBlur}
               renderInput={params => (
                 <TextField 
                   {...params} 
@@ -519,7 +543,7 @@ export default function Register(props) {
                   onKeyPress={(event) => {
                     if (event.key === 'Enter') {
                         event.preventDefault();
-                        if (values.addDomain.trim()){
+                        if (values.addDomain.trim() && !values.domain.includes(values.addDomain)){
                           setFieldValue('domain',[...values.domain,values.addDomain]);
                           setFieldValue('addDomain','');
                         }
@@ -736,7 +760,6 @@ export default function Register(props) {
                         <React.Fragment key={index}>
                           <div>
                           <Autocomplete
-                            freeSolo
                             options={universityNames} 
                             key={index}
                             disableClearable
@@ -745,12 +768,20 @@ export default function Register(props) {
                             onChange={(e, value) => {
                               setFieldValue(`uniApplied.${index}.name`, value)
                             }}
+                            filterOptions={(options, params) => {
+                              const filtered = filter(options, params);
+                              if (params.inputValue !== ''&& !filtered.includes("Other")) {
+                              filtered.push("Other");
+                               }
+                                return filtered;
+                            }}
                             onBlur={handleBlur}
                             renderInput={params => (
                               <TextField {...params} 
                                 name={`uniApplied.${index}.name`} 
                                 value={value.name} 
                                 onChange={handleChange} 
+                                onBlur={()=>(value.name=universityNames.includes(value.name)||value.name===''?value.name:"Other")}
                                 label="University Name" 
                                 margin="normal" 
                                 variant="filled" 

--- a/webapp/src/Components/register.js
+++ b/webapp/src/Components/register.js
@@ -57,7 +57,6 @@ export default function Register(props) {
     if(!componentDidMount){
       axios.get('/api/tags')
       .then(function(response){
-        console.log(response)
         response.data.forEach((item,index)=>{
           if(item.isSchool){
             if(!universityArr.includes(item)){
@@ -105,11 +104,11 @@ export default function Register(props) {
       rejects: user.rejects
     })
     .then(function (response) {
-      console.log(response);
+      console.log("Registration Successful");
       props.setRegister(0);
     })
     .catch(function (error) {
-      console.log(error);
+      console.log("Registration Failed");
     });
   }
 
@@ -469,7 +468,6 @@ export default function Register(props) {
             values.domain.forEach(async (item,index)=>
               user.domain[index]=await getObjectId(tagNames,tagArr,item,false)
             )
-            console.log(user);
             submitAxios();
             //@Backend Submit Function for Sign-Up
         }}

--- a/webapp/src/Components/register.js
+++ b/webapp/src/Components/register.js
@@ -234,9 +234,9 @@ export default function Register(props) {
             if (!values.lname){
               errors.lname = "Fill this field"
             }
-            if (!values.university){
-              errors.university = "Fill this field"
-            }
+            // if (!values.university){
+            //   errors.university = "Fill this field"
+            // }
             if (!values.department){
               errors.department = "Fill this field"
             }

--- a/webapp/src/Components/tagRequests.js
+++ b/webapp/src/Components/tagRequests.js
@@ -1,4 +1,4 @@
-const axios = require('axios');
+//const axios = require('axios');
 
 export const getTagById = (id,ObjectArr) => {
     	var name;
@@ -19,17 +19,17 @@ export const getObjectId = async (NamesArr,ObjectArr,ObjectName,isSchoolBool) =>
 		  }
 		})
 	}
-	else{
-		try{
-		  var response= await axios.post('/api/tags' , {
-		    name: ObjectName,
-		    isSchool: isSchoolBool
-		  })
-		  id=response.data._id;
-		}
-		catch(error){
-		  console.error(error);
-		}
-	}
+	// else{
+	// 	try{
+	// 	  var response= await axios.post('/api/tags' , {
+	// 	    name: ObjectName,
+	// 	    isSchool: isSchoolBool
+	// 	  })
+	// 	  id=response.data._id;
+	// 	}
+	// 	catch(error){
+	// 	  console.error(error);
+	// 	}
+	// }
 	return id;
 }


### PR DESCRIPTION
### Disabled creation of tags for users that do not have admin permissions.
If the user enters any text for a tag input which doesnt match any existing tags then the input will automatically be changed to "Other". Also added on option for "Other" in the autocomplete suggestions which is displayed for all inputs (even if they do not contain any characters which match "other")
I have commented the old code (not deleted) because we might implement something similar to it in later versions.

> **Note**: You must have a tag named "Other" in the database for this to work. If not , you will have to create one manually. I'm also disabling validation for these fields temporarily but please add a tag "Other" to your database.  

Misc: 
1) Also fixed a bug where reloading the Edit Profile page would show a warning related to asynchronous tasks in an unmounted component.
2) Cleaned up console log messages.