### PR TITLE
Add Colors to morgan and winston logs.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "printWidth": 100,
-  "singleQuote": true
+  "singleQuote": true,
+  "prettier.arrowParens": "always"
 }

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const helmet = require('helmet');
 const path = require('path');
 
 const logger = require('./config/logger');
+const { devProfile } = require('./config/morganConfig');
 const { directives, limiter, options } = require('./config/middlewares');
 
 const { userRouter, forumRouter, tagRouter, chatRouter } = require('./routes');
@@ -24,7 +25,7 @@ app.use(bodyParser.json());
 app.use(bodyParser.raw());
 
 // morgan
-app.use(morgan('dev'));
+app.use(morgan(devProfile));
 
 // express-rate-limit
 app.use(limiter);

--- a/config/logger.js
+++ b/config/logger.js
@@ -1,34 +1,55 @@
 const { createLogger, transports, format } = require('winston');
+const chalk = require('chalk');
 const path = require('path');
-
 
 // Setting the path for log file
 const filename = path.join('logDir', 'loggers.log');
 
+/**
+ * Function to set color settings of a strin
+ */
+function formatMessage(info) {
+  let level = info.level;
+  if (level) {
+    level = level.toUpperCase();
+  }
+  const msg = `${info.timestamp}  ${info.level} [${info.label}]: ${info.message}`;
+  if (level === 'INFO') {
+    return chalk.dim.cyan(msg);
+  }
+  if (level === 'WARN') {
+    //* Hex color is dark orange
+    //* Note :italic is not widely supported : refer chalk.js npm page : https://www.npmjs.com/package/chalk
+    return chalk.hex('#FF8C00').italic(msg);
+  }
+  if (level === 'DEBUG') {
+    //* Hex color is dark orange
+    //* Note :italic is not widely supported : refer chalk.js npm page : https://www.npmjs.com/package/chalk
+    return chalk.yellowBright(msg);
+  }
+  if (level === 'ERROR') {
+    //* Hex color is Red, the defaul red was a bit meh..!
+    return chalk.hex('#ff0000').bold(msg);
+  }
+  return msg;
+}
 // Config for Winston logger
 const LOGGER_OPTIONS = {
-  level: 'info',
+  level: 'debug',
   handleExceptions: true,
   format: format.combine(
     format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
     format.label({ label: path.basename(process.mainModule.filename) }),
-    format.printf(
-      (info) => `${info.timestamp}  ${info.level} [${info.label}]: ${info.message}`,
-    ),
+    format.printf(info => formatMessage(info))
   ),
   transports: [
     new transports.Console({
       format: format.combine(
-        format.json(), format.colorize(),
-        format.printf(
-          (info) => `${info.timestamp}  ${info.level} [${info.label}]: ${info.message}`,
-        ),
-      ),
-    }),
-    // new transports.File({
-    //   filename,
-    // }),
-  ],
+        format.json(),
+        format.printf(info => formatMessage(info))
+      )
+    })
+  ]
 };
 
 /**
@@ -87,14 +108,15 @@ function deleted(model, doc) {
 
 module.exports = {
   baseLogger: logger,
-  info: (s) => logger.info(s),
-  error: (s) => logger.error(s),
-  debug: (s) => logger.debug(s),
-  log: (s) => logger.log(s),
+  info: s => logger.info(s),
+  error: s => logger.error(s),
+  debug: s => logger.debug(s),
+  log: (level, s) => logger.log(level, s),
+  warn: s => logger.warn(s),
 
   created,
   readOne,
   readMany,
   updated,
-  deleted,
+  deleted
 };

--- a/config/morganConfig.js
+++ b/config/morganConfig.js
@@ -1,0 +1,40 @@
+const chalk = require('chalk');
+
+const info = msg => {
+  return chalk.dim.white(msg);
+};
+const success = msg => {
+  return chalk.hex('#adff2f').italic(msg);
+};
+const redirect = msg => {
+  return chalk.cyan(msg);
+};
+const reqError = msg => {
+  //* Hex color dark orange
+  return chalk.hex('#ff8c00').bold(msg);
+};
+const serverError = msg => {
+  return chalk.hex('#ff0000').bold(msg);
+};
+const getColor = status => {
+  if (status < 200) return success;
+  if (status >= 200 && status < 300) return success;
+  if (status >= 300 && status < 400) return redirect;
+  if (status >= 400 && status < 500) return reqError;
+  if (status >= 500) return serverError;
+};
+
+//*:method :url :status :response-time ms - :res[content-length]
+const devProfile = (tokens, req, res) => {
+  color = getColor(tokens.status(req, res));
+  return [
+    color(tokens.method(req, res)),
+    chalk.white(tokens.url(req, res)),
+    color(tokens.status(req, res)),
+    color(tokens['response-time'](req, res) + ' ms'),
+    '- :',
+    color(tokens.res(req, res, 'content-length'))
+  ].join(' ');
+};
+
+module.exports = { devProfile };

--- a/index.js
+++ b/index.js
@@ -8,20 +8,20 @@ const { port, host } = require('./config/constants');
  * Sets up the project
  */
 async function main() {
-	// Wait for MongoDB connection
-	await dbConnection();
+  // Wait for MongoDB connection
+  await dbConnection();
 
-	// Websockets setup
-	const server = attachChatApp(app);
+  // Websockets setup
+  const server = attachChatApp(app);
 
-	// Return after setup
-	return server;
+  // Return after setup
+  return server;
 }
 
 // -----
 
-main().then((server) => {
-	server.listen(port, host, () => {
-		logger.info(`🔥 Server started listening on http://${host}:${port}`);
-	});
+main().then(server => {
+  server.listen(port, host, () => {
+    logger.info(`🔥 Server started listening on http://${host}:${port}`);
+  });
 });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "apidoc": "^0.20.1",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
+    "chalk": "^4.0.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/test/tag.js
+++ b/test/tag.js
@@ -19,7 +19,7 @@ describe(config.GROUP_TAG_TESTS, async () => {
       .request(server)
       .post('/api/tags/')
       .send({});
-    expect(tag1).to.have.status(400);
+    expect(tag1).to.have.status(401);
     expect(tag1.body).to.be.a('object');
     expect(tag1.body).to.not.have.property('tag');
     expect(tag1.body).to.have.property('name');


### PR DESCRIPTION
Add colors to morgan and winston logs
Add config function for Morgan logging with colors.

Winston logs with colors :
![basic_log](https://user-images.githubusercontent.com/54112038/78451995-5f13c000-76a6-11ea-9f87-e2cec511cbe7.png)

Morgan log with colors :
![morgan_log](https://user-images.githubusercontent.com/54112038/78452005-7357bd00-76a6-11ea-9ee8-baf17f1e4264.png)

Morgan Logs with color in test :
![morgan_log_test](https://user-images.githubusercontent.com/54112038/78452014-7e125200-76a6-11ea-9729-13d379bd410e.png)
